### PR TITLE
Support adding custom widgets/actions/menus to the gallery popup window

### DIFF
--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -164,6 +164,13 @@ RibbonGalleryPopupListWidget
    :members:
    :show-inheritance:
 
+RibbonPopupWidget
+~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ribbon.gallery.RibbonPopupWidget
+   :members:
+   :show-inheritance:
+
 Ribbon Tool Button
 ------------------
 
@@ -212,5 +219,12 @@ RibbonMenu
 ~~~~~~~~~~
 
 .. autoclass:: ribbon.menu.RibbonMenu
+   :members:
+   :show-inheritance:
+
+RibbonPermanentMenu
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ribbon.menu.RibbonPermanentMenu
    :members:
    :show-inheritance:

--- a/main.py
+++ b/main.py
@@ -8,8 +8,9 @@ from ribbon.ribbonbar import RibbonStyle
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
-    app.setFont(QtGui.QFont("Times New Roman", 8))
+    app.setFont(QtGui.QFont("Times New Roman", 10))
     app.setStyle("Windows")
+    app.setStyleSheet(open("styles/default.qss", "r").read())
 
     window = QtWidgets.QMainWindow()
     ribbon = RibbonBar()
@@ -159,6 +160,15 @@ if __name__ == "__main__":
     gallery = panel.addGallery(popupHideOnClick=True)
     for i in range(100):
         gallery.addToggleButton(f'item {i+1}', QIcon("icons/close.png"))
+    popupMenu = gallery.popupMenu()
+    submenu = popupMenu.addMenu(QIcon("icons/close.png"), 'Submenu')
+    submenu.addAction(QIcon("icons/close.png"), "Action 4")
+    popupMenu.addAction(QtGui.QIcon("icons/close.png"), "Action 1")
+    popupMenu.addAction(QtGui.QIcon("icons/close.png"), "Action 2")
+    popupMenu.addSeparator()
+    popupMenu.addWidget(QtWidgets.QLabel("This is a custom widget"))
+    formLayout = popupMenu.addFormLayoutWidget()
+    formLayout.addRow(QtWidgets.QLabel("Row 1"), QtWidgets.QLineEdit())
 
     label = QtWidgets.QLabel("Ribbon Test Window")
     label.setFont(QtGui.QFont("Arial", 20))

--- a/ribbon/__init__.py
+++ b/ribbon/__init__.py
@@ -2,4 +2,4 @@ from .category import RibbonCategoryStyle
 from .panel import RibbonSpaceFindMode
 from .ribbonbar import RibbonBar, RibbonStyle
 from .toolbutton import RibbonButtonStyle
-from .menu import RibbonMenu
+from .menu import RibbonMenu, RibbonPermanentMenu

--- a/ribbon/menu.py
+++ b/ribbon/menu.py
@@ -1,5 +1,6 @@
 import typing
 
+from PyQt5 import QtGui
 from qtpy import QtWidgets, QtCore
 
 
@@ -26,6 +27,7 @@ class RibbonMenu(QtWidgets.QMenu):
             title = ''
             parent = args[0] if len(args) > 0 else kwargs.get('parent', None)
         super().__init__(title, parent)
+        self.setFont(QtWidgets.QApplication.instance().font())
 
     def addWidget(self, widget: QtWidgets.QWidget):
         """Add a widget to the menu.
@@ -99,3 +101,18 @@ class RibbonMenu(QtWidgets.QMenu):
         label = QtWidgets.QLabel(text)
         label.setAlignment(alignment)
         self.addWidget(label)
+
+
+class RibbonPermanentMenu(RibbonMenu):
+    """
+    A permanent menu.
+    """
+    actionAdded = QtCore.Signal(QtWidgets.QAction)
+
+    def hideEvent(self, a0: QtGui.QHideEvent) -> None:
+        self.show()
+
+    def actionEvent(self, a0: QtGui.QActionEvent) -> None:
+        if a0.type() == QtGui.QActionEvent.ActionAdded:
+            self.actionAdded.emit(a0.action())
+        super().actionEvent(a0)

--- a/styles/default.qss
+++ b/styles/default.qss
@@ -44,6 +44,28 @@ RibbonGalleryButton {
 
 RibbonGalleryListWidget {
     border: 0px solid transparent;
+    background-color: white;
+}
+
+RibbonPopupWidget {
+    border: 1px solid gray;
+    border-radius: 5px;
+    background-color: white;
+}
+
+RibbonMenu, QMenu {
+    border: 1px solid gray;
+    background-color: white;
+}
+
+RibbonPermanentMenu {
+    border: none;
+    border-radius: 5px;
+    background-color: white;
+}
+
+QMenu:selected {
+    background-color: #e0e0e0;
 }
 
 RibbonApplicationButton {


### PR DESCRIPTION
Adding custom widgets to the gallery popup windows is now supported. A permanent menu (RibbonPermanentMenu class) is added to the popup window, the RibbonGallery.popupMenu() method returns a RibbonPermanentMenu instance, we can use it too add our custom widgets, actions, or submenus. 