### PR TITLE
Update title widget layout to avoid extra vertical spaces usage

### DIFF
--- a/pyqtribbon/ribbonbar.py
+++ b/pyqtribbon/ribbonbar.py
@@ -45,8 +45,6 @@ class RibbonBar(QtWidgets.QMenuBar):
 
     #: Signal, the help button was clicked.
     helpButtonClicked = QtCore.Signal(bool)
-    #: Signal, the file button was clicked.
-    fileButtonClicked = QtCore.Signal()
 
     #: The categories of the ribbon.
     _categories: typing.Dict[str, RibbonCategory] = {}
@@ -59,13 +57,13 @@ class RibbonBar(QtWidgets.QMenuBar):
     _ribbonVisible = True
 
     #: heights of the ribbon elements
-    _ribbonHeight = 200
+    _ribbonHeight = 180
 
     #: current tab index
     _currentTabIndex = 0
 
     @typing.overload
-    def __init__(self, title: str = "", maxRows=6, parent=None):
+    def __init__(self, title: str = "Ribbon Bar Title", maxRows=6, parent=None):
         pass
 
     @typing.overload
@@ -80,7 +78,7 @@ class RibbonBar(QtWidgets.QMenuBar):
         :param parent: The parent widget of the ribbon.
         """
         if (args and not isinstance(args[0], QtWidgets.QWidget)) or ("title" in kwargs or "maxRows" in kwargs):
-            title = args[0] if len(args) > 0 else kwargs.get("title", "")
+            title = args[0] if len(args) > 0 else kwargs.get("title", "Ribbon Bar Title")
             maxRows = args[1] if len(args) > 1 else kwargs.get("maxRows", 6)
             parent = args[2] if len(args) > 2 else kwargs.get("parent", None)
         else:
@@ -472,10 +470,6 @@ class RibbonBar(QtWidgets.QMenuBar):
 
         :param index: tab index
         """
-        if index == 0:
-            self.fileButtonClicked.emit()  # type: ignore
-            index = self._currentTabIndex
-            self._titleWidget.tabBar().setCurrentIndex(index)
         self._currentTabIndex = index
         title = self._titleWidget.tabBar().tabText(index)  # 0 is the file tab
         if title in self._categories:

--- a/pyqtribbon/titlewidget.py
+++ b/pyqtribbon/titlewidget.py
@@ -65,17 +65,9 @@ class RibbonTitleWidget(QtWidgets.QFrame):
         super().__init__(parent)
         # Tab bar layout
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
-        self._mainLayout = QtWidgets.QVBoxLayout(self)
-        self._mainLayout.setContentsMargins(0, 0, 0, 0)
-        self._mainLayout.setSpacing(0)
-        self._titleLayout = QtWidgets.QHBoxLayout()
-        self._titleLayout.setContentsMargins(0, 0, 0, 0)
-        self._titleLayout.setSpacing(0)
-        self._tabBarLayout = QtWidgets.QHBoxLayout()
+        self._tabBarLayout = QtWidgets.QHBoxLayout(self)
         self._tabBarLayout.setContentsMargins(0, 0, 0, 0)
         self._tabBarLayout.setSpacing(0)
-        self._mainLayout.addLayout(self._titleLayout)
-        self._mainLayout.addLayout(self._tabBarLayout)
 
         # Application
         self._applicationButton = RibbonApplicationButton()
@@ -123,7 +115,6 @@ class RibbonTitleWidget(QtWidgets.QFrame):
         self._tabBar.setFont(font)
         self._tabBar.setShape(QtWidgets.QTabBar.RoundedNorth)
         self._tabBar.setDocumentMode(True)
-        self._tabBar.addTab("File")
 
         # Title label
         self._titleLabel = RibbonTitleLabel(self)
@@ -134,10 +125,10 @@ class RibbonTitleWidget(QtWidgets.QFrame):
         font.setPointSize(font.pointSize() + 3)
         self._titleLabel.setFont(font)
 
-        self._titleLayout.addWidget(self._quickAccessToolBarWidget, 0)
-        self._titleLayout.addWidget(self._titleLabel, 1)
-        self._tabBarLayout.addWidget(self._tabBar, 1)
-        self._tabBarLayout.addWidget(self._rightToolBar, 0)
+        self._tabBarLayout.addWidget(self._quickAccessToolBarWidget, 0, QtCore.Qt.AlignVCenter)
+        self._tabBarLayout.addWidget(self._tabBar, 0, QtCore.Qt.AlignVCenter)
+        self._tabBarLayout.addWidget(self._titleLabel, 1, QtCore.Qt.AlignVCenter)
+        self._tabBarLayout.addWidget(self._rightToolBar, 0, QtCore.Qt.AlignVCenter)
 
     def applicationButton(self) -> RibbonApplicationButton:
         """Return the application button."""
@@ -155,7 +146,7 @@ class RibbonTitleWidget(QtWidgets.QFrame):
 
         :param widget: The widget to add.
         """
-        self._titleLayout.addWidget(widget)
+        self._tabBarLayout.addWidget(widget)
 
     def insertTitleWidget(self, index: int, widget: QtWidgets.QWidget):
         """Insert a widget to the title layout.
@@ -163,14 +154,14 @@ class RibbonTitleWidget(QtWidgets.QFrame):
         :param index: The index to insert the widget.
         :param widget: The widget to insert.
         """
-        self._titleLayout.insertWidget(index, widget)
+        self._tabBarLayout.insertWidget(index, widget)
 
     def removeTitleWidget(self, widget: QtWidgets.QWidget):
         """Remove a widget from the title layout.
 
         :param widget: The widget to remove.
         """
-        self._titleLayout.removeWidget(widget)
+        self._tabBarLayout.removeWidget(widget)
 
     def tabBar(self) -> RibbonTabBar:
         """Return the tab bar of the ribbon.


### PR DESCRIPTION
## Previous Title Layout

![image](https://user-images.githubusercontent.com/47051427/226932329-9190d3fd-e3af-47de-89c0-3eef8f67ec9c.png)

## Updated Title Layout

![image](https://user-images.githubusercontent.com/47051427/226932140-4f3a5276-3273-4b1c-a6a1-529a8916a0fa.png)

## Checklists

- [x] Horizontal layout: quick access toolbar, ribbon tab bar, tile label, and right toolbar 
- [x] Remove default `File` button in the tab bar, the application button should do the work
- [x] Remove `fileButtonClicked` Signal
- [x] Reduce default ribbon height to `180`
- [x] Update default title label to `Ribbon Bar Title`